### PR TITLE
Rename filter method to 'process'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class Foo
 
     public function doSomething($rawValue)
     {
-        $filteredValue = $this->filter->filter($rawValue);
+        $filteredValue = $this->filter->process($rawValue);
         
         // do something with filtered value
         

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -9,5 +9,5 @@ namespace Zee\Filter;
 
 interface Filter
 {
-    public function filter($value);
+    public function process($value);
 }


### PR DESCRIPTION
The old method `filter` looks ugly in code, e.q. `$filter->filter($value)`.
Also it may confuse that pupose of it is only to filter and remove something
from incoming values, which is incorrect.
The filter can process values in any ways: transform, map, serialize, etc.